### PR TITLE
fix: alert user on sync queue drop and notify on successful drain

### DIFF
--- a/apps/parakeet/src/modules/session/hooks/useSyncQueue.ts
+++ b/apps/parakeet/src/modules/session/hooks/useSyncQueue.ts
@@ -37,10 +37,16 @@ export function useSyncQueue() {
     if (processingRef.current) return
     processingRef.current = true
 
+    let syncedCount = 0
+
     try {
       for (const op of queue) {
         if (op.retryCount >= MAX_RETRIES) {
           dequeue(op.id)
+          Alert.alert(
+            'Sync Failed',
+            'Your workout data could not be saved after multiple attempts. Please check your connection and try again.',
+          )
           continue
         }
 
@@ -57,6 +63,7 @@ export function useSyncQueue() {
             })
 
             dequeue(op.id)
+            syncedCount++
 
             await queryClient.invalidateQueries({ queryKey: ['session'] })
             await queryClient.invalidateQueries({ queryKey: ['sessions', 'completed'] })
@@ -75,6 +82,15 @@ export function useSyncQueue() {
             )
           }
         }
+      }
+
+      if (syncedCount > 0) {
+        Alert.alert(
+          'Workouts Synced',
+          syncedCount === 1
+            ? 'Your workout has been saved successfully.'
+            : `${syncedCount} workouts have been saved successfully.`,
+        )
       }
     } finally {
       processingRef.current = false


### PR DESCRIPTION
## Summary
- Shows `Alert.alert` when a sync operation is dropped after MAX_RETRIES (5) so the user knows their data wasn't saved
- Shows success alert when queued workouts sync after reconnecting

Closes #17, closes #34

## Test plan
- [ ] Typecheck passes
- [ ] Complete a session while offline — verify alert on successful sync when back online
- [ ] Simulate persistent network failure — verify alert after 5 retry failures