### PR TITLE
fix: pass completedAt, add captureException, deduplicate capitalize

### DIFF
--- a/apps/parakeet/src/app/(auth)/onboarding/review.tsx
+++ b/apps/parakeet/src/app/(auth)/onboarding/review.tsx
@@ -15,6 +15,7 @@ import { useAuth } from '@modules/auth'
 import { qk } from '@platform/query'
 import { generateProgram, nextDateForWeekday, DEFAULT_TRAINING_DAYS } from '@parakeet/training-engine'
 import { captureException } from '@platform/utils/captureException'
+import { capitalize } from '@shared/utils/string'
 import { colors, spacing, typography, radii } from '../../../theme'
 
 // ── Constants ─────────────────────────────────────────────────────────────────
@@ -26,10 +27,6 @@ const MONTH_SHORT = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Se
 
 function formatSessionDate(date: Date): string {
   return `${DAY_LABELS[date.getDay()]} ${MONTH_SHORT[date.getMonth()]} ${date.getDate()}`
-}
-
-function capitalize(str: string): string {
-  return str ? str.charAt(0).toUpperCase() + str.slice(1) : str
 }
 
 // ── Screen ───────────────────────────────────────────────────────────────────

--- a/apps/parakeet/src/app/(tabs)/program.tsx
+++ b/apps/parakeet/src/app/(tabs)/program.tsx
@@ -26,6 +26,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { router } from 'expo-router';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { WeekRow } from '../../components/program/WeekRow';
+import { capitalize } from '@shared/utils/string';
 import { colors, spacing, typography } from '../../theme';
 
 export default function ProgramScreen() {
@@ -248,9 +249,6 @@ export default function ProgramScreen() {
   );
 }
 
-function capitalize(str: string): string {
-  return str ? str.charAt(0).toUpperCase() + str.slice(1) : str;
-}
 
 const styles = StyleSheet.create({
   loadingContainer: {

--- a/apps/parakeet/src/app/(tabs)/session/[sessionId].tsx
+++ b/apps/parakeet/src/app/(tabs)/session/[sessionId].tsx
@@ -23,6 +23,7 @@ import { RestTimer } from '../../../components/training/RestTimer';
 import { RpeQuickPicker } from '../../../components/training/RpeQuickPicker';
 import { SetRow } from '../../../components/training/SetRow';
 import { WarmupSection } from '../../../components/training/WarmupSection';
+import { capitalize } from '@shared/utils/string';
 import { colors } from '../../../theme';
 
 // ── Types ────────────────────────────────────────────────────────────────────
@@ -72,11 +73,6 @@ const DEFAULT_MAIN_REST_SECONDS = 180;
 const DEFAULT_AUX_REST_SECONDS = 90;
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
-
-function capitalize(value: string): string {
-  if (!value) return value;
-  return value.charAt(0).toUpperCase() + value.slice(1);
-}
 
 function formatExerciseName(name: string): string {
   return name

--- a/apps/parakeet/src/app/(tabs)/session/complete.tsx
+++ b/apps/parakeet/src/app/(tabs)/session/complete.tsx
@@ -118,6 +118,7 @@ export default function CompleteScreen() {
         auxiliarySets: completionPayload.auxiliarySets,
         sessionRpe,
         startedAt,
+        completedAt: new Date(),
       });
 
       // Stamp cycle phase on the session log (no-op if tracking disabled)

--- a/apps/parakeet/src/app/(tabs)/session/soreness.tsx
+++ b/apps/parakeet/src/app/(tabs)/session/soreness.tsx
@@ -22,6 +22,7 @@ import {
   LIFT_PRIMARY_SORENESS_MUSCLES,
   MUSCLE_LABELS_FULL,
 } from '@shared/constants/training';
+import { capitalize } from '@shared/utils/string';
 import { router, useLocalSearchParams } from 'expo-router';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { BackLink } from '../../../components/navigation/BackLink';
@@ -34,11 +35,6 @@ type Session = Awaited<ReturnType<typeof getSession>>;
 // ── Constants ────────────────────────────────────────────────────────────────
 
 const RATING_LEVELS = [1, 2, 3, 4, 5] as const;
-
-function capitalize(value: string): string {
-  if (!value) return value;
-  return value.charAt(0).toUpperCase() + value.slice(1);
-}
 
 // ── Sub-component: single muscle rating row ───────────────────────────────
 

--- a/apps/parakeet/src/app/(tabs)/today.tsx
+++ b/apps/parakeet/src/app/(tabs)/today.tsx
@@ -27,6 +27,8 @@ import {
   COMPACT_VOLUME_MUSCLES,
   MUSCLE_LABELS_COMPACT,
 } from '@shared/constants/training';
+import { captureException } from '@platform/utils/captureException';
+import { capitalize } from '@shared/utils/string';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { router } from 'expo-router';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -128,13 +130,12 @@ function WorkoutDoneCard({
     retry: false,
   });
 
-  if (error) console.warn('Motivational message error:', error);
+  if (error) {
+    console.warn('Motivational message error:', error);
+    captureException(error);
+  }
 
-  const lifts = sessions
-    .map(
-      (s) => s.primary_lift.charAt(0).toUpperCase() + s.primary_lift.slice(1)
-    )
-    .join(', ');
+  const lifts = sessions.map((s) => capitalize(s.primary_lift)).join(', ');
 
   return (
     <View style={styles.workoutDoneCard}>

--- a/apps/parakeet/src/app/history/[sessionId].tsx
+++ b/apps/parakeet/src/app/history/[sessionId].tsx
@@ -12,16 +12,13 @@ import { getSession, getSessionLog } from '@modules/session'
 import { BackLink } from '../../components/navigation/BackLink'
 import { colors, radii, spacing, typography } from '../../theme'
 import { formatDate, formatTime } from '@shared/utils/date'
+import { capitalize } from '@shared/utils/string'
 import type { Lift } from '@parakeet/shared-types'
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 function gramsToKg(grams: number): string {
   return (grams / 1000).toFixed(1)
-}
-
-function capitalize(s: string): string {
-  return s.charAt(0).toUpperCase() + s.slice(1)
 }
 
 const LIFT_LABELS: Record<Lift, string> = {

--- a/apps/parakeet/src/components/achievements/StarCard.tsx
+++ b/apps/parakeet/src/components/achievements/StarCard.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react'
 import { Animated, StyleSheet, Text, View } from 'react-native'
 import type { PR } from '@parakeet/training-engine'
+import { capitalize } from '@shared/utils/string'
 import { colors, radii, spacing, typography } from '../../theme'
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -9,12 +10,6 @@ interface StarCardProps {
   pr: PR
   /** Delay in ms before the slide-up animation starts (for staggering). */
   delay?: number
-}
-
-// ── Helpers ───────────────────────────────────────────────────────────────────
-
-function capitalize(s: string): string {
-  return s.charAt(0).toUpperCase() + s.slice(1)
 }
 
 function formatPRText(pr: PR): string {

--- a/apps/parakeet/src/components/program/SessionSummary.tsx
+++ b/apps/parakeet/src/components/program/SessionSummary.tsx
@@ -7,14 +7,10 @@ import type { ProgramSession } from '@modules/program'
 import { useInProgressSession } from '@modules/session'
 import { useSessionStore } from '@platform/store/sessionStore'
 import { formatDate } from '@shared/utils/date'
+import { capitalize } from '@shared/utils/string'
 
 interface SessionSummaryProps {
   session: ProgramSession
-}
-
-function capitalize(value: string): string {
-  if (!value) return value
-  return value.charAt(0).toUpperCase() + value.slice(1)
 }
 
 export function SessionSummary({ session }: SessionSummaryProps) {

--- a/apps/parakeet/src/components/session/LiftHistorySheet.tsx
+++ b/apps/parakeet/src/components/session/LiftHistorySheet.tsx
@@ -8,6 +8,7 @@ import { useAuth } from '@modules/auth'
 import { useNetworkStatus } from '@platform/network'
 import { colors, spacing, typography } from '../../theme'
 import { formatDate } from '@shared/utils/date'
+import { capitalize } from '@shared/utils/string'
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -15,13 +16,6 @@ interface Props {
   lift: string
   visible: boolean
   onClose: () => void
-}
-
-// ── Helpers ───────────────────────────────────────────────────────────────────
-
-function capitalize(v: string) {
-  if (!v) return v
-  return v.charAt(0).toUpperCase() + v.slice(1)
 }
 
 

--- a/apps/parakeet/src/components/session/ReturnToSessionBanner.tsx
+++ b/apps/parakeet/src/components/session/ReturnToSessionBanner.tsx
@@ -7,12 +7,8 @@ import { useSessionStore } from '@platform/store/sessionStore'
 import { getRestTimerPrefs } from '@modules/settings'
 import { detectOvertimeEdge, useRestNotifications } from '@modules/session'
 import { formatMMSS } from '../../shared/utils'
+import { capitalize } from '@shared/utils/string'
 import { colors, radii, spacing, typography } from '../../theme'
-
-function capitalize(value: string): string {
-  if (!value) return value
-  return value.charAt(0).toUpperCase() + value.slice(1)
-}
 
 export function ReturnToSessionBanner() {
   useRestNotifications()

--- a/apps/parakeet/src/shared/utils/index.ts
+++ b/apps/parakeet/src/shared/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './date'
 export * from './duration'
+export * from './string'

--- a/apps/parakeet/src/shared/utils/string.ts
+++ b/apps/parakeet/src/shared/utils/string.ts
@@ -1,0 +1,3 @@
+export function capitalize(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}


### PR DESCRIPTION
## Summary
- Passes `completedAt: new Date()` in `complete.tsx` so timestamp reflects user action, not DB write time
- Adds `captureException` to motivational message error handler (was console.warn only)
- Extracts `capitalize()` to `@shared/utils/string.ts` and removes 9 duplicate definitions

Closes #37, closes #43, closes #42

## Test plan
- [ ] Typecheck passes
- [ ] Complete a session — verify `completed_at` timestamp is accurate
- [ ] Session complete screen renders even if motivational message fails
- [ ] All screens that used capitalize still display correctly