### PR TITLE
refactor: fix cross-module deep imports to use public APIs

### DIFF
--- a/apps/parakeet/src/modules/jit/lib/jit.ts
+++ b/apps/parakeet/src/modules/jit/lib/jit.ts
@@ -23,7 +23,7 @@ import { getMrvMevConfig } from '@modules/training-volume'
 import { getBarWeightKg, getJITStrategyOverride, getUserRestOverrides, getWarmupConfig } from '@modules/settings'
 import type { Json } from '@platform/supabase'
 import { typedSupabase } from '@platform/supabase'
-import { fetchProfileSex } from '../../session/data/session.repository'
+import { fetchProfileSex } from '@modules/session'
 import { estimateOneRmKgFromProfile } from './max-estimation'
 
 type Session = Awaited<ReturnType<typeof getSession>>

--- a/apps/parakeet/src/modules/program/application/program.service.ts
+++ b/apps/parakeet/src/modules/program/application/program.service.ts
@@ -20,7 +20,7 @@ import {
   updateProgramStatusIfActive,
   updateUnendingSessionCounter,
 } from '../data/program.repository';
-import { cancelPlannedSessionsForProgram } from '../../session/data/session.repository';
+import { cancelPlannedSessionsForProgram } from '@modules/session';
 import { getAuthenticatedUserId } from '../data/profile.repository';
 import { getAuxiliaryPools } from '../lib/auxiliary-config';
 import { getCurrentMaxes } from '../lib/lifter-maxes';

--- a/apps/parakeet/src/modules/program/index.ts
+++ b/apps/parakeet/src/modules/program/index.ts
@@ -1,4 +1,5 @@
 export * from './application/program.service';
+export * from './application/unending-session';
 export * from './hooks/useActiveProgram';
 export * from './lib/programs';
 export * from './lib/auxiliary-config';

--- a/apps/parakeet/src/modules/session/application/session.service.ts
+++ b/apps/parakeet/src/modules/session/application/session.service.ts
@@ -37,8 +37,7 @@ import {
   updateSessionToPlanned,
   updateSessionToSkipped,
 } from '../data/session.repository';
-import { fetchActiveProgramMode } from '../../program/data/program.repository';
-import { appendNextUnendingSession, type UnendingProgramRef } from '../../program/application/unending-session';
+import { fetchActiveProgramMode, appendNextUnendingSession, type UnendingProgramRef } from '@modules/program';
 import type {
   CompletedSessionListItem,
   CompleteSessionInput,

--- a/apps/parakeet/src/modules/session/index.ts
+++ b/apps/parakeet/src/modules/session/index.ts
@@ -8,3 +8,4 @@ export * from './hooks/useSyncQueue';
 export * from './lib/sessions';
 export * from './utils/overtime-edge';
 export * from './utils/session-sorting';
+export { fetchProfileSex, cancelPlannedSessionsForProgram } from './data/session.repository';


### PR DESCRIPTION
## Summary
- Exports `fetchActiveProgramMode`, `appendNextUnendingSession`, `UnendingProgramRef` from `@modules/program`
- Exports `fetchProfileSex`, `cancelPlannedSessionsForProgram` from `@modules/session`
- Updates 4 deep imports in `session.service.ts`, `jit.ts`, and `program.service.ts` to use module public APIs

Closes #29

## Test plan
- [ ] Typecheck passes
- [ ] Module boundary check passes: `npm run check:module-boundary`