### PR TITLE
fix: filter fetchTodaySession to current date for scheduled programs

### DIFF
--- a/apps/parakeet/src/modules/session/data/session.repository.ts
+++ b/apps/parakeet/src/modules/session/data/session.repository.ts
@@ -105,12 +105,14 @@ export async function fetchTodaySession(
   if (completedTodayError) throw completedTodayError;
   if (completedTodayData) return completedTodayData;
 
+  const today = new Date().toISOString().split('T')[0];
   const { data: plannedData, error: plannedError } = await typedSupabase
     .from('sessions')
     .select('*')
     .eq('user_id', userId)
     .eq('status', 'planned')
     .not('planned_date', 'is', null)
+    .gte('planned_date', today)
     .order('planned_date', { ascending: true })
     .limit(1)
     .maybeSingle();


### PR DESCRIPTION
## Summary
- Adds `.gte('planned_date', today)` filter to the planned session query in `fetchTodaySession`
- Missed sessions no longer surface as today's workout — they stay planned until `markMissedSessions` transitions them
- In-progress sessions intentionally have no date filter (user should finish or abandon them)

Closes #14

## Test plan
- [ ] Typecheck passes
- [ ] Miss a session on day X, open app on day X+1 — see day X+1's session (or rest day), not the missed one
- [ ] In-progress sessions from previous days still show correctly