### PR TITLE
fix: persist warmupCompleted as array, verify cycle phase and volume

### DIFF
--- a/apps/parakeet/src/components/training/WarmupSection.tsx
+++ b/apps/parakeet/src/components/training/WarmupSection.tsx
@@ -12,7 +12,7 @@ interface WarmupSet {
 
 export interface WarmupSectionProps {
   sets: WarmupSet[]
-  completedIndices: Set<number>
+  completedIndices: number[]
   onToggle: (index: number, done: boolean) => void
   barWeightKg?: number
 }
@@ -98,7 +98,7 @@ export function WarmupSection({ sets, completedIndices, onToggle, barWeightKg = 
               key={index}
               index={index}
               set={set}
-              isDone={completedIndices.has(index)}
+              isDone={completedIndices.includes(index)}
               onToggle={onToggle}
               barWeightKg={barWeightKg}
             />

--- a/apps/parakeet/src/modules/cycle-tracking/lib/cycle-tracking.ts
+++ b/apps/parakeet/src/modules/cycle-tracking/lib/cycle-tracking.ts
@@ -103,6 +103,7 @@ export async function stampCyclePhaseOnSession(
   userId: string,
   sessionId: string,
 ): Promise<void> {
+  // No-ops when cycle tracking is disabled or no period start date is recorded.
   const context = await getCurrentCycleContext(userId)
   if (!context) return
   const { error } = await typedSupabase

--- a/apps/parakeet/src/platform/store/sessionStore.test.ts
+++ b/apps/parakeet/src/platform/store/sessionStore.test.ts
@@ -47,13 +47,13 @@ describe('sessionStore persistence', () => {
     expect(merged.startedAt).toBeUndefined();
   });
 
-  it('merge always initializes warmupCompleted as empty Set', () => {
+  it('merge preserves warmupCompleted array from persisted state', () => {
     const opts = (useSessionStore as any).persist.getOptions();
     const merged = opts.merge(
       { warmupCompleted: [1, 2, 3] },
       useSessionStore.getState()
     );
-    expect(merged.warmupCompleted).toBeInstanceOf(Set);
-    expect(merged.warmupCompleted.size).toBe(0);
+    expect(Array.isArray(merged.warmupCompleted)).toBe(true);
+    expect(merged.warmupCompleted).toEqual([1, 2, 3]);
   });
 });

--- a/apps/parakeet/src/platform/store/sessionStore.ts
+++ b/apps/parakeet/src/platform/store/sessionStore.ts
@@ -37,7 +37,7 @@ interface SessionState {
   plannedSets: { weight_kg: number; reps: number }[]
   actualSets: ActualSet[]
   auxiliarySets: AuxiliaryActualSet[]
-  warmupCompleted: Set<number>
+  warmupCompleted: number[]
   sessionRpe: number | undefined
   startedAt: Date | undefined
   sessionMeta: {
@@ -77,7 +77,7 @@ export const useSessionStore = create<SessionState>()(
       plannedSets: [],
       actualSets: [],
       auxiliarySets: [],
-      warmupCompleted: new Set(),
+      warmupCompleted: [],
       sessionRpe: undefined,
       startedAt: undefined,
       sessionMeta: null,
@@ -94,7 +94,7 @@ export const useSessionStore = create<SessionState>()(
           reps_completed: s.reps,
           is_completed: false,
         })),
-        warmupCompleted: new Set(),
+        warmupCompleted: [],
         sessionRpe: undefined,
         timerState: null,
       }),
@@ -140,12 +140,11 @@ export const useSessionStore = create<SessionState>()(
         };
       }),
 
-      setWarmupDone: (index, done) => set((state) => {
-        const next = new Set(state.warmupCompleted)
-        if (done) next.add(index)
-        else next.delete(index)
-        return { warmupCompleted: next }
-      }),
+      setWarmupDone: (index, done) => set((state) => ({
+        warmupCompleted: done
+          ? state.warmupCompleted.includes(index) ? state.warmupCompleted : [...state.warmupCompleted, index]
+          : state.warmupCompleted.filter((i) => i !== index),
+      })),
 
       setSessionRpe: (rpe) => set({ sessionRpe: rpe }),
 
@@ -196,7 +195,7 @@ export const useSessionStore = create<SessionState>()(
         plannedSets: [],
         actualSets: [],
         auxiliarySets: [],
-        warmupCompleted: new Set(),
+        warmupCompleted: [],
         sessionRpe: undefined,
         startedAt: undefined,
         sessionMeta: null,
@@ -212,6 +211,7 @@ export const useSessionStore = create<SessionState>()(
         plannedSets: state.plannedSets,
         actualSets: state.actualSets,
         auxiliarySets: state.auxiliarySets,
+        warmupCompleted: state.warmupCompleted,
         sessionRpe: state.sessionRpe,
         sessionMeta: state.sessionMeta,
         cachedJitData: state.cachedJitData,
@@ -223,7 +223,6 @@ export const useSessionStore = create<SessionState>()(
         return {
           ...current,
           ...p,
-          warmupCompleted: new Set(),
           startedAt: p?.startedAt ? new Date(p.startedAt as unknown as string) : undefined,
         };
       },


### PR DESCRIPTION
## Summary
- Converts `warmupCompleted` from `Set<number>` to `number[]` for JSON serialization safety
- Adds `warmupCompleted` to Zustand persist `partialize` — survives app restarts
- Updates `WarmupSection` component to use `.includes()` instead of `.has()`
- Verified: `stampCyclePhaseOnSession` already no-ops when tracking not configured (added comment)
- Verified: ad-hoc auxiliary sets already count toward weekly MRV in volume dashboard

Closes #27, closes #38, closes #31, closes #26

## Test plan
- [ ] Typecheck passes
- [ ] Start a session, check warmup items, kill app, reopen — checkmarks preserved
- [ ] Session store test passes