### PR TITLE
docs: update deload+disruption interaction, sync spec, test counts

### DIFF
--- a/docs/FEATURE_MAP.md
+++ b/docs/FEATURE_MAP.md
@@ -138,7 +138,7 @@ Pure TypeScript. No React, no Supabase.
 What it contains: 1RM formulas, cube scheduler, loading calculator, program generator, JIT session generator, MRV/MEV calculator, performance adjuster, auxiliary rotator, soreness adjuster, warmup calculator, Wilks formula, cycle phase calculator, PR detection, cycle review generator, hybrid JIT strategy, developer suggestion engine.
 
 Entry: `packages/training-engine/src/index.ts`
-Tests: Vitest, 336 tests — `nx run training-engine:test`
+Tests: Vitest, 409 tests — `nx run training-engine:test`
 
 ### `@parakeet/shared-types`
 

--- a/docs/specs/04-engine/engine-007-jit-session-generator.md
+++ b/docs/specs/04-engine/engine-007-jit-session-generator.md
@@ -94,6 +94,7 @@ interface AuxiliaryWork {
   - Set `skippedMainLift = true` if remaining <= 0
 - [x] **Step 5 — Disruption override**
   - If any activeDisruptions affect this lift: apply disruption-adjuster reductions (takes full precedence over steps 2–4)
+  - **Deload interaction**: During deload weeks the base sets from Step 1 are already reduced (lower volume/intensity). Disruption reductions in Step 5 apply on top of those already-reduced values, so the effects compound conservatively. This is intentional — a disruption during a deload means even lighter work, which is the correct conservative response.
 - [x] **Step 6 — Auxiliary work**
   - For each auxiliary exercise (2 total): base 3–4 sets at 67.5% 1RM (default), per-exercise rep target, RPE 7.5
   - Per-exercise weight %: `AUX_WEIGHT_PCT[exercise] ?? 0.675` — divergent exercises (Good Mornings, Bulgarian Split Squat, OHP, JM Press, curls) use lower percentages; see table in engine-019

--- a/docs/specs/09-mobile/mobile-009-offline-sync.md
+++ b/docs/specs/09-mobile/mobile-009-offline-sync.md
@@ -13,24 +13,25 @@ Handling offline scenarios during active workout logging. The session logging sc
 
 **Strategy: Optimistic local state with background sync queue**
 
-**`apps/parakeet/store/sessionStore.ts` (Zustand + MMKV persistence):**
-- All set updates are written to MMKV immediately (survives app crash)
+**`src/platform/store/sessionStore.ts` (Zustand + AsyncStorage persistence):**
+- All set updates are written to AsyncStorage immediately via Zustand `persist` middleware (survives app crash)
 - State is never lost between app background/foreground cycles
 - `actualSets` array is the authoritative in-progress state
+- `warmupCompleted` (Set) and `startedAt` (Date) require special handling: `warmupCompleted` is excluded from persistence; `startedAt` is rehydrated via a custom `merge` function
 
-**`apps/parakeet/store/syncStore.ts` (pending operations queue):**
-- Queue of pending Supabase SDK operations: `{ id, operation: 'complete_session' | 'skip_session', payload, createdAt }`
+**`src/platform/store/syncStore.ts` (pending operations queue):**
+- Queue of pending Supabase SDK operations: `{ id, operation: 'complete_session', payload, createdAt, retryCount }`
+- Only `complete_session` is queued; skip operations are fire-and-forget (no queue entry)
 - Operations are added optimistically before the Supabase call
 - On success: remove from queue
-- On failure (network error): keep in queue, retry on reconnect
-- On non-retryable error (Supabase constraint violation, auth error): surface to user, do not retry
+- On failure (network error): keep in queue, increment `retryCount`, retry on reconnect
+- On non-retryable error (Supabase constraint violation, auth error): dequeue + alert user
 
 **Session completion offline handling:**
 - If `completeSession()` Supabase SDK call fails due to network:
-  1. Store complete payload in MMKV under key `pending_session_completion_:sessionId`
+  1. Enqueue operation in `syncStore` (persisted to AsyncStorage)
   2. Show success UI to user (optimistic) with a small sync indicator
-  3. Register background fetch task (`expo-background-fetch`) to retry when online
-  4. On next app foreground + connectivity: retry the pending Supabase `upsert` to `session_logs`
+  3. On next foreground + connectivity restore: `useSyncQueue` drains the queue automatically (no background fetch task)
 
 **Connectivity detection:**
 - Show offline banner in session screen when connectivity is lost


### PR DESCRIPTION
## Summary
- Documents deload + disruption interaction in JIT spec (intentional conservative compounding)
- Updates mobile-009 offline sync spec to match actual implementation (Zustand + AsyncStorage, not MMKV)
- Updates FEATURE_MAP.md test count from 336 to 409

Closes #23, closes #35, closes #36

## Test plan
- [ ] Docs review only — no code changes