### PR TITLE
fix: timed exercises show duration in session history (#111)

### DIFF
--- a/apps/parakeet/src/app/history/[sessionId].tsx
+++ b/apps/parakeet/src/app/history/[sessionId].tsx
@@ -434,44 +434,69 @@ export default function SessionDetailScreen() {
         )}
 
         {/* Auxiliary sets */}
-        {Object.entries(auxByExercise).map(([exercise, sets]) => (
-          <View key={exercise}>
-            <Text style={styles.sectionHeader}>
-              {capitalize(exercise.replace(/_/g, ' '))}
-            </Text>
-            <View style={styles.setsTable}>
-              <View style={styles.tableHeader}>
-                <Text style={[styles.tableCell, styles.tableCellSet]}>Set</Text>
-                <Text style={[styles.tableCell, styles.tableCellWeight]}>
-                  Weight
-                </Text>
-                <Text style={[styles.tableCell, styles.tableCellReps]}>
-                  Reps
-                </Text>
-                <Text style={[styles.tableCell, styles.tableCellRpe]}>RPE</Text>
-              </View>
-              {sets.map((set, i) => (
-                <View
-                  key={i}
-                  style={[styles.tableRow, i % 2 === 1 && styles.tableRowAlt]}
-                >
+        {Object.entries(auxByExercise).map(([exercise, sets]) => {
+          const isTimed = sets[0]?.exercise_type === 'timed';
+          return (
+            <View key={exercise}>
+              <Text style={styles.sectionHeader}>
+                {capitalize(exercise.replace(/_/g, ' '))}
+              </Text>
+              <View style={styles.setsTable}>
+                <View style={styles.tableHeader}>
                   <Text style={[styles.tableCell, styles.tableCellSet]}>
-                    {set.set_number}
+                    {isTimed ? 'Round' : 'Set'}
                   </Text>
-                  <Text style={[styles.tableCell, styles.tableCellWeight]}>
-                    {gramsToKg(set.weight_grams).toFixed(1)} kg
-                  </Text>
-                  <Text style={[styles.tableCell, styles.tableCellReps]}>
-                    {set.reps_completed}
-                  </Text>
-                  <Text style={[styles.tableCell, styles.tableCellRpe]}>
-                    {set.rpe_actual != null ? set.rpe_actual : '—'}
-                  </Text>
+                  {isTimed ? (
+                    <Text style={[styles.tableCell, styles.tableCellWeight]}>
+                      Duration
+                    </Text>
+                  ) : (
+                    <>
+                      <Text style={[styles.tableCell, styles.tableCellWeight]}>
+                        Weight
+                      </Text>
+                      <Text style={[styles.tableCell, styles.tableCellReps]}>
+                        Reps
+                      </Text>
+                      <Text style={[styles.tableCell, styles.tableCellRpe]}>
+                        RPE
+                      </Text>
+                    </>
+                  )}
                 </View>
-              ))}
+                {sets.map((set, i) => (
+                  <View
+                    key={i}
+                    style={[styles.tableRow, i % 2 === 1 && styles.tableRowAlt]}
+                  >
+                    <Text style={[styles.tableCell, styles.tableCellSet]}>
+                      {set.set_number}
+                    </Text>
+                    {isTimed ? (
+                      <Text style={[styles.tableCell, styles.tableCellWeight]}>
+                        {set.reps_completed} min
+                      </Text>
+                    ) : (
+                      <>
+                        <Text
+                          style={[styles.tableCell, styles.tableCellWeight]}
+                        >
+                          {gramsToKg(set.weight_grams).toFixed(1)} kg
+                        </Text>
+                        <Text style={[styles.tableCell, styles.tableCellReps]}>
+                          {set.reps_completed}
+                        </Text>
+                        <Text style={[styles.tableCell, styles.tableCellRpe]}>
+                          {set.rpe_actual != null ? set.rpe_actual : '—'}
+                        </Text>
+                      </>
+                    )}
+                  </View>
+                ))}
+              </View>
             </View>
-          </View>
-        ))}
+          );
+        })}
 
         {!log && (
           <Text style={styles.emptyText}>


### PR DESCRIPTION
## Summary

- Timed exercises (Plank, Run - Treadmill, Ski Erg, etc.) were showing Weight and Reps columns in the session history detail screen instead of duration.
- Fix checks `exercise_type === 'timed'` on the first set of each auxiliary exercise group and renders a "Round / Duration (min)" table instead of "Set / Weight / Reps / RPE".
- Matches the display convention already used in the active session's `SetRow` component.

## Changes

- `apps/parakeet/src/app/history/[sessionId].tsx` — auxiliary sets section now branches on `isTimed` to render either the timed layout (Round + Duration in min) or the standard layout (Set + Weight + Reps + RPE).

## Test plan

- [ ] Open a completed session that contains timed auxiliary exercises (e.g. Plank, Run - Treadmill)
- [ ] Verify the table header shows "Round" and "Duration" (not "Set", "Weight", "Reps")
- [ ] Verify each row shows the round number and duration in minutes (e.g. "1 · 10 min")
- [ ] Verify standard (weighted/bodyweight) auxiliary exercises still show Set / Weight / Reps / RPE unchanged
- [ ] `tsc --noEmit` passes — confirmed locally
- [ ] All 324 tests pass — confirmed locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)