### PR TITLE
fix: correct clean variant weightPct ordering

### DIFF
--- a/docs/domain/exercise-catalog.md
+++ b/docs/domain/exercise-catalog.md
@@ -66,6 +66,9 @@ At the reference 1RM, output equals the linear formula. Above it, weight grows s
 | Good Mornings          | deadlift        | 0.40      | weighted |
 | Lat Pulldown           | deadlift        | 0.28      | weighted |
 | Seated Machine Row     | deadlift        | 0.28      | weighted |
+| Power Clean            | deadlift        | 0.55      | weighted |
+| Barbell Hang Clean     | deadlift        | 0.50      | weighted |
+| Clean and Jerk         | deadlift        | 0.45      | weighted |
 
 Default fallback: 0.675
 

--- a/packages/training-engine/src/auxiliary/exercise-catalog.test.ts
+++ b/packages/training-engine/src/auxiliary/exercise-catalog.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { computeAuxWeight, getWeightPct } from './exercise-catalog';
+
+describe('clean variant weight ordering', () => {
+  it('Power Clean >= Hang Clean > Clean and Jerk', () => {
+    const powerClean = getWeightPct('Power Clean');
+    const hangClean = getWeightPct('Barbell Hang Clean');
+    const cleanAndJerk = getWeightPct('Clean and Jerk');
+
+    expect(powerClean).toBeGreaterThanOrEqual(hangClean);
+    expect(hangClean).toBeGreaterThan(cleanAndJerk);
+  });
+
+  it('computeAuxWeight reflects correct ordering for a 180kg deadlift 1RM', () => {
+    const opts = { oneRmKg: 180, lift: 'deadlift' as const };
+    const powerClean = computeAuxWeight({ exercise: 'Power Clean', ...opts });
+    const hangClean = computeAuxWeight({
+      exercise: 'Barbell Hang Clean',
+      ...opts,
+    });
+    const cleanAndJerk = computeAuxWeight({
+      exercise: 'Clean and Jerk',
+      ...opts,
+    });
+
+    expect(powerClean).toBeGreaterThanOrEqual(hangClean);
+    expect(hangClean).toBeGreaterThan(cleanAndJerk);
+
+    // Sanity: all in a reasonable range (40-60% of DL 1RM)
+    expect(powerClean).toBeCloseTo(180 * 0.55, 1);
+    expect(hangClean).toBeCloseTo(180 * 0.5, 1);
+    expect(cleanAndJerk).toBeCloseTo(180 * 0.45, 1);
+  });
+});

--- a/packages/training-engine/src/auxiliary/exercise-catalog.ts
+++ b/packages/training-engine/src/auxiliary/exercise-catalog.ts
@@ -519,7 +519,8 @@ export const EXERCISE_CATALOG: ExerciseCatalogEntry[] = [
       { muscle: 'glutes', contribution: 0.5 },
       { muscle: 'shoulders', contribution: 0.5 },
     ],
-    weightPct: 0.55,
+    // Jerk is the limiting factor — lighter than hang clean or power clean
+    weightPct: 0.45,
     repTarget: 3,
     complexityTier: 'complex',
   },
@@ -532,7 +533,8 @@ export const EXERCISE_CATALOG: ExerciseCatalogEntry[] = [
       { muscle: 'upper_back', contribution: 1.0 },
       { muscle: 'glutes', contribution: 0.5 },
     ],
-    weightPct: 0.5,
+    // Full pull from floor — heaviest of the three clean variants
+    weightPct: 0.55,
     repTarget: 3,
     complexityTier: 'complex',
   },


### PR DESCRIPTION
## Summary
- **Hang clean** was prescribed lighter than **clean and jerk** (0.50 vs 0.55), but the jerk overhead is the limiting factor — you can't C&J as much as you can clean
- Reordered: Power Clean 0.55 ≥ Hang Clean 0.50 > Clean and Jerk 0.45
- Added regression test enforcing the ordering invariant
- Updated domain doc with all three clean variant weightPct values

Fixes #134

## Test plan
- [x] New `exercise-catalog.test.ts` — 2 tests verifying `getWeightPct` and `computeAuxWeight` ordering
- [x] All 1214 training-engine tests pass
- [x] `tsc --noEmit` clean
- [x] Module boundary check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)