### PR TITLE
fix: review quick wins — error handling, disruption filter, LLM logging

### DIFF
--- a/apps/parakeet/src/app/(tabs)/program.tsx
+++ b/apps/parakeet/src/app/(tabs)/program.tsx
@@ -26,6 +26,7 @@ import type { ProgramSession } from '@modules/program';
 import { useInProgressSession, useTodaySession } from '@modules/session';
 import type { IntensityType, Lift } from '@parakeet/shared-types';
 import { qk } from '@platform/query';
+import { captureException } from '@platform/utils/captureException';
 import { useSessionStore } from '@platform/store/sessionStore';
 import { capitalize } from '@shared/utils/string';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
@@ -289,7 +290,9 @@ export default function ProgramScreen() {
           formulaConfig
         );
       }
-    } catch {}
+    } catch (err) {
+      captureException(err);
+    }
     const firstSet = estimatedSets?.[0] ?? null;
     const setCount = estimatedSets?.length ?? null;
     const lastSessionRpe = liftHistory?.entries?.[0]?.sessionRpe ?? null;

--- a/apps/parakeet/src/app/(tabs)/today.tsx
+++ b/apps/parakeet/src/app/(tabs)/today.tsx
@@ -582,7 +582,7 @@ export default function TodayScreen() {
             }
           });
         })
-        .catch(() => {});
+        .catch(captureException);
     }, [user?.id])
   );
 
@@ -597,7 +597,7 @@ export default function TodayScreen() {
           }
           setPendingCalibration(JSON.parse(raw));
         })
-        .catch(() => {});
+        .catch(captureException);
     }, [])
   );
 

--- a/docs/design/rest-timer.md
+++ b/docs/design/rest-timer.md
@@ -1,6 +1,6 @@
 # Feature: Rest Timer
 
-**Status**: Designed (not implemented)
+**Status**: Implemented
 **Date**: 2026-02-25
 
 ## Overview

--- a/docs/specs/implementation-status.md
+++ b/docs/specs/implementation-status.md
@@ -8,7 +8,7 @@ For details on any item, see the linked spec file.
 
 ## Training Engine (`packages/training-engine`)
 
-1169 tests passing (Vitest). All specs implemented. Bug fix: `generateAuxiliaryAssignments` now generates assignments for all blocks (not just 1–3); `blockNumber` widened to `number` throughout; `getIntensityTypeForWeek` now cycles correctly for block 4+.
+1214 tests passing (Vitest). All specs implemented. Bug fix: `generateAuxiliaryAssignments` now generates assignments for all blocks (not just 1–3); `blockNumber` widened to `number` throughout; `getIntensityTypeForWeek` now cycles correctly for block 4+.
 
 - [x] engine-001: 1RM formulas — Epley, grams↔kg helpers
 - [x] engine-002: Cube method scheduler — blocks.ts

--- a/packages/training-engine/src/generator/__tests__/hybrid-jit-generator.test.ts
+++ b/packages/training-engine/src/generator/__tests__/hybrid-jit-generator.test.ts
@@ -215,7 +215,7 @@ describe('HybridJITGenerator', () => {
     expect(typeof logDivergence.weightPct).toBe('number');
   });
 
-  it('does not call logger when LLM fails', async () => {
+  it('calls logger with fallback reason when LLM fails', async () => {
     const logger = vi.fn();
     const llmGen = new LLMJITGenerator();
     vi.spyOn(llmGen, 'generate').mockRejectedValueOnce(new Error('timeout'));
@@ -227,7 +227,10 @@ describe('HybridJITGenerator', () => {
     );
     await gen.generate(baseInput());
 
-    expect(logger).not.toHaveBeenCalled();
+    expect(logger).toHaveBeenCalledOnce();
+    const divergence = logger.mock.calls[0][3];
+    expect(divergence.rpeContextSummary).toContain('LLM_FALLBACK');
+    expect(divergence.rpeContextSummary).toContain('timeout');
   });
 
   it('does not call logger when no logger provided (no error)', async () => {

--- a/packages/training-engine/src/generator/hybrid-jit-generator.ts
+++ b/packages/training-engine/src/generator/hybrid-jit-generator.ts
@@ -74,8 +74,20 @@ export class HybridJITGenerator implements JITGeneratorStrategy {
       throw (formulaResult as PromiseRejectedResult).reason;
     }
 
-    // LLM failed → fall back to formula output
+    // LLM failed → fall back to formula output; surface reason for app-layer logging
     if (!llmOutput) {
+      const llmError = (llmResult as PromiseRejectedResult).reason;
+      if (this.logger) {
+        try {
+          this.logger(input, formulaOutput, formulaOutput, {
+            weightPct: 0,
+            setDelta: 0,
+            rpeContextSummary: `LLM_FALLBACK: ${llmError instanceof Error ? llmError.message : String(llmError)}`,
+          });
+        } catch {
+          // logging errors are silently swallowed
+        }
+      }
       return { ...formulaOutput, jit_strategy: 'formula_fallback' };
     }
 

--- a/packages/training-engine/src/generator/steps/applyDisruptionAdjustment.ts
+++ b/packages/training-engine/src/generator/steps/applyDisruptionAdjustment.ts
@@ -10,7 +10,9 @@ export function applyDisruptionAdjustment(
   const preCount = ctx.plannedCount;
   const relevantDisruptions = input.activeDisruptions.filter(
     (d) =>
-      d.affected_lifts === null || d.affected_lifts.includes(input.primaryLift)
+      d.affected_lifts === null ||
+      d.affected_lifts.length === 0 ||
+      d.affected_lifts.includes(input.primaryLift)
   );
 
   if (relevantDisruptions.length > 0 && !ctx.inRecoveryMode) {


### PR DESCRIPTION
## Summary
- Replace silent `.catch(() => {})` with `captureException` in today.tsx (pending_weekly_review, pending_calibration_prompt)
- Add `captureException` to empty `catch {}` in program.tsx calculateSets
- Fix `affected_lifts: []` bug in `applyDisruptionAdjustment` — empty array was silently ignored instead of treated as "all lifts"
- Log LLM failure reason in `HybridJITGenerator` via `ComparisonLogger` so `formula_fallback` events are debuggable
- Update stale docs: rest-timer.md status, implementation-status test count

## Test plan
- [x] `tsc --noEmit` clean
- [x] 528 generator tests passing (hybrid-jit-generator test updated)
- [x] Module boundary check passing
- [ ] Verify disruption with `affected_lifts: []` now applies to all lifts
- [ ] Verify LLM fallback logs include error message in `jit_comparison_logs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)