### PR TITLE
feat: injury-derived soreness injection for MEV top-up (GH#166)

### DIFF
--- a/apps/parakeet/src/modules/jit/lib/jit.ts
+++ b/apps/parakeet/src/modules/jit/lib/jit.ts
@@ -29,6 +29,7 @@ import {
 } from '@parakeet/shared-types';
 import type { Lift } from '@parakeet/shared-types';
 import {
+  computeInjurySorenessOverrides,
   computeWeightDeviation,
   computeWorkingOneRm,
   createAdHocJITOutput,
@@ -40,6 +41,7 @@ import {
   getMusclesForExercise,
   getMusclesForLift,
   LIFTS,
+  mergeSorenessRatings,
   reviewJITDecision,
   rpeSetMultiplier,
 } from '@parakeet/training-engine';
@@ -348,37 +350,11 @@ export async function runJITForSession(
   // Inject injury-derived soreness for muscles of affected lifts (GH#166).
   // This lets the exercise scorer naturally route around injured muscles
   // without needing a separate "safe exercises" list.
-  const INJURY_SORENESS: Record<string, SorenessLevel> = {
-    minor: 5 as SorenessLevel,
-    moderate: 7 as SorenessLevel,
-  };
-  const injurySorenessOverrides: Partial<Record<MuscleGroup, SorenessLevel>> =
-    {};
-  for (const d of activeDisruptions) {
-    if (d.disruption_type !== 'injury' || !d.affected_lifts) continue;
-    const injuredSoreness = INJURY_SORENESS[d.severity];
-    if (!injuredSoreness) continue; // major → session skipped entirely
-    for (const affectedLift of d.affected_lifts) {
-      const parsed = LiftSchema.safeParse(affectedLift);
-      if (!parsed.success) continue;
-      for (const { muscle } of getMusclesForLift(parsed.data)) {
-        const current = injurySorenessOverrides[muscle] ?? 0;
-        if (injuredSoreness > current) {
-          injurySorenessOverrides[muscle] = injuredSoreness;
-        }
-      }
-    }
-  }
-  // Merge: injury soreness wins only if it's higher than actual soreness
-  const mergedSorenessRatings: Partial<Record<MuscleGroup, SorenessLevel>> = {
-    ...sorenessRatings,
-  };
-  for (const [muscle, level] of Object.entries(injurySorenessOverrides)) {
-    const existing = mergedSorenessRatings[muscle as MuscleGroup] ?? 0;
-    if (level > existing) {
-      mergedSorenessRatings[muscle as MuscleGroup] = level;
-    }
-  }
+  const injuryOverrides = computeInjurySorenessOverrides(activeDisruptions);
+  const mergedSorenessRatings = mergeSorenessRatings(
+    sorenessRatings,
+    injuryOverrides
+  );
 
   // Merge all three lift pools for widest top-up selection (engine-027)
   const auxiliaryPool = allPools

--- a/packages/training-engine/src/adjustments/injury-soreness.test.ts
+++ b/packages/training-engine/src/adjustments/injury-soreness.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+
+import { makeDisruption } from '../__test-helpers__/fixtures';
+import type { MuscleGroup } from '../types';
+import type { SorenessLevel } from './soreness-adjuster';
+import {
+  computeInjurySorenessOverrides,
+  INJURY_SORENESS,
+  mergeSorenessRatings,
+} from './injury-soreness';
+
+describe('computeInjurySorenessOverrides', () => {
+  it('returns empty for no disruptions', () => {
+    expect(computeInjurySorenessOverrides([])).toEqual({});
+  });
+
+  it('returns empty for non-injury disruptions', () => {
+    const illness = {
+      ...makeDisruption('moderate'),
+      disruption_type: 'illness' as const,
+    };
+    expect(computeInjurySorenessOverrides([illness])).toEqual({});
+  });
+
+  it('returns empty for major injury (session skipped entirely)', () => {
+    expect(computeInjurySorenessOverrides([makeDisruption('major')])).toEqual(
+      {}
+    );
+  });
+
+  it('injects soreness for squat muscles on minor injury', () => {
+    const result = computeInjurySorenessOverrides([
+      makeDisruption('minor', 'squat'),
+    ]);
+    expect(result['quads']).toBe(INJURY_SORENESS['minor']);
+    expect(result['glutes']).toBe(INJURY_SORENESS['minor']);
+  });
+
+  it('injects soreness for deadlift muscles on moderate injury', () => {
+    const result = computeInjurySorenessOverrides([
+      makeDisruption('moderate', 'deadlift'),
+    ]);
+    expect(result['hamstrings']).toBe(INJURY_SORENESS['moderate']);
+    expect(result['lower_back']).toBe(INJURY_SORENESS['moderate']);
+    expect(result['upper_back']).toBe(INJURY_SORENESS['moderate']);
+  });
+
+  it('takes highest soreness when multiple injuries overlap', () => {
+    const result = computeInjurySorenessOverrides([
+      makeDisruption('minor', 'squat'), // glutes = 5
+      makeDisruption('moderate', 'deadlift'), // glutes = 7
+    ]);
+    // glutes are trained by both squat and deadlift — moderate wins
+    expect(result['glutes']).toBe(INJURY_SORENESS['moderate']);
+  });
+
+  it('handles null affected_lifts', () => {
+    const d = { ...makeDisruption('moderate'), affected_lifts: null };
+    expect(computeInjurySorenessOverrides([d])).toEqual({});
+  });
+
+  it('does not set soreness for muscles not trained by affected lift', () => {
+    const result = computeInjurySorenessOverrides([
+      makeDisruption('moderate', 'squat'),
+    ]);
+    // chest is not a squat muscle
+    expect(result['chest']).toBeUndefined();
+  });
+});
+
+describe('mergeSorenessRatings', () => {
+  it('returns actual ratings when no overrides', () => {
+    const actual: Partial<Record<MuscleGroup, SorenessLevel>> = {
+      quads: 3 as SorenessLevel,
+    };
+    expect(mergeSorenessRatings(actual, {})).toEqual(actual);
+  });
+
+  it('injury soreness wins when higher', () => {
+    const actual: Partial<Record<MuscleGroup, SorenessLevel>> = {
+      quads: 3 as SorenessLevel,
+    };
+    const overrides: Partial<Record<MuscleGroup, SorenessLevel>> = {
+      quads: 7 as SorenessLevel,
+    };
+    expect(mergeSorenessRatings(actual, overrides)['quads']).toBe(7);
+  });
+
+  it('actual soreness wins when higher', () => {
+    const actual: Partial<Record<MuscleGroup, SorenessLevel>> = {
+      quads: 9 as SorenessLevel,
+    };
+    const overrides: Partial<Record<MuscleGroup, SorenessLevel>> = {
+      quads: 5 as SorenessLevel,
+    };
+    expect(mergeSorenessRatings(actual, overrides)['quads']).toBe(9);
+  });
+
+  it('adds muscles only in overrides', () => {
+    const actual: Partial<Record<MuscleGroup, SorenessLevel>> = {};
+    const overrides: Partial<Record<MuscleGroup, SorenessLevel>> = {
+      hamstrings: 7 as SorenessLevel,
+    };
+    expect(mergeSorenessRatings(actual, overrides)['hamstrings']).toBe(7);
+  });
+});

--- a/packages/training-engine/src/adjustments/injury-soreness.ts
+++ b/packages/training-engine/src/adjustments/injury-soreness.ts
@@ -1,0 +1,73 @@
+import type { Lift, TrainingDisruption } from '@parakeet/shared-types';
+
+import type { MuscleGroup } from '../types';
+import { getMusclesForLift } from '../volume/muscle-mapper';
+import type { SorenessLevel } from './soreness-adjuster';
+
+/**
+ * Soreness levels injected for injury disruptions by severity.
+ * Chosen to create meaningful exercise scorer penalties without
+ * triggering recovery mode (which fires at soreness >= 9).
+ *
+ * - Minor (5): between mild (3) and sore (6) — moderate penalty
+ * - Moderate (7): between sore (6) and very sore (8) — strong penalty
+ * - Major: not mapped — session is already skipped by disruption adjuster
+ */
+export const INJURY_SORENESS: Partial<Record<string, SorenessLevel>> = {
+  minor: 5 as SorenessLevel,
+  moderate: 7 as SorenessLevel,
+};
+
+const VALID_LIFTS = new Set<string>(['squat', 'bench', 'deadlift']);
+
+/**
+ * Compute synthetic soreness overrides from active injury disruptions.
+ *
+ * For each injury with affected_lifts, maps those lifts to their muscle
+ * groups and assigns a severity-based soreness level. When multiple injuries
+ * overlap, the highest soreness wins per muscle.
+ *
+ * When all three lifts are affected, all muscles get elevated soreness and
+ * the top-up scorer distributes volume roughly uniformly (no muscle is
+ * preferred over another).
+ */
+export function computeInjurySorenessOverrides(
+  activeDisruptions: TrainingDisruption[]
+): Partial<Record<MuscleGroup, SorenessLevel>> {
+  const overrides: Partial<Record<MuscleGroup, SorenessLevel>> = {};
+
+  for (const d of activeDisruptions) {
+    if (d.disruption_type !== 'injury' || !d.affected_lifts) continue;
+    const injuredSoreness = INJURY_SORENESS[d.severity];
+    if (!injuredSoreness) continue; // major → session skipped entirely
+    for (const affectedLift of d.affected_lifts) {
+      if (!VALID_LIFTS.has(affectedLift)) continue;
+      for (const { muscle } of getMusclesForLift(affectedLift as Lift)) {
+        const current = overrides[muscle] ?? 0;
+        if (injuredSoreness > current) {
+          overrides[muscle] = injuredSoreness;
+        }
+      }
+    }
+  }
+
+  return overrides;
+}
+
+/**
+ * Merge injury-derived soreness with actual soreness ratings.
+ * Injury soreness only wins when higher than what the lifter reported.
+ */
+export function mergeSorenessRatings(
+  actual: Partial<Record<MuscleGroup, SorenessLevel>>,
+  injuryOverrides: Partial<Record<MuscleGroup, SorenessLevel>>
+): Partial<Record<MuscleGroup, SorenessLevel>> {
+  const merged: Partial<Record<MuscleGroup, SorenessLevel>> = { ...actual };
+  for (const [muscle, level] of Object.entries(injuryOverrides)) {
+    const existing = merged[muscle as MuscleGroup] ?? 0;
+    if (level > existing) {
+      merged[muscle as MuscleGroup] = level;
+    }
+  }
+  return merged;
+}

--- a/packages/training-engine/src/modules/adjustments/index.ts
+++ b/packages/training-engine/src/modules/adjustments/index.ts
@@ -6,3 +6,4 @@ export * from '../../adjustments/cycle-phase-adjuster';
 export * from '../../adjustments/intra-session-adapter';
 export * from '../../adjustments/volume-recovery';
 export * from '../../adjustments/weight-autoregulation';
+export * from '../../adjustments/injury-soreness';


### PR DESCRIPTION
## Summary
- When an active injury disruption affects specific lifts, auto-inject high soreness ratings for those lifts' muscle groups into JIT input
- The existing exercise scorer naturally deprioritizes exercises that load sore muscles — no new UI, no new DB columns
- Replaces the closed #169 (safe_exercises list approach) with a simpler mechanism that builds on existing infrastructure

## How it works
| Injury severity | Injected soreness | Effect on scorer |
|---|---|---|
| Minor | 5 | Moderate penalty — exercises for injured muscles ranked lower |
| Moderate | 7 | Strong penalty — scorer strongly prefers exercises for non-injured muscles |
| Major | N/A | Session already skipped by disruption adjuster |

Injury soreness merges with actual soreness ratings — only wins when higher than what the lifter reported.

## Example
Knee injury (moderate) affecting squat → injects soreness 7 for quads, glutes, hamstrings, lower_back. On bench day, MEV top-up scorer prefers lat pulldown (upper_back) over leg press (quads) because quads are "sore."

## Test plan
- [x] Typecheck clean
- [ ] Manual: report moderate squat injury → verify bench session top-ups avoid quad-dominant exercises

Depends on #168
Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)