### PR TITLE
fix(jit): handle null block_number on programmatic sessions

### DIFF
--- a/apps/parakeet/src/modules/jit/lib/jit.ts
+++ b/apps/parakeet/src/modules/jit/lib/jit.ts
@@ -108,15 +108,28 @@ export async function runJITForSession(
   const lift = LiftSchema.parse(session.primary_lift);
   const intensityType = IntensityTypeSchema.parse(session.intensity_type);
 
-  // For ad-hoc sessions (no program), derive block number from intensity type
+  // Ad-hoc sessions (no program) have a null block_number by design. Legacy
+  // programmatic sessions can also reach this point with a null block_number
+  // (Sentry react-native#122700262 — older row predates the column being
+  // populated for that program). In both cases, derive the block from
+  // intensity_type instead of crashing the JIT pipeline.
   const isAdHoc = session.program_id === null;
-  const blockNumber = isAdHoc
-    ? intensityType === 'heavy'
-      ? 1
-      : intensityType === 'explosive'
-        ? 2
-        : 3
-    : BlockNumberSchema.parse(session.block_number);
+  const blockNumber =
+    session.block_number !== null
+      ? BlockNumberSchema.parse(session.block_number)
+      : intensityType === 'heavy'
+        ? 1
+        : intensityType === 'explosive'
+          ? 2
+          : 3;
+  if (!isAdHoc && session.block_number === null) {
+    captureException(
+      new Error(
+        `JIT: programmatic session ${session.id} has null block_number; ` +
+          `derived block=${blockNumber} from intensity_type=${intensityType}`
+      )
+    );
+  }
 
   const biologicalSex = await getProfileSex(userId);
 

--- a/apps/parakeet/src/modules/jit/lib/jit.ts
+++ b/apps/parakeet/src/modules/jit/lib/jit.ts
@@ -31,7 +31,7 @@ import {
   IntensityTypeSchema,
   LiftSchema,
 } from '@parakeet/shared-types';
-import type { Lift } from '@parakeet/shared-types';
+import type { IntensityType, Lift } from '@parakeet/shared-types';
 import {
   computeDivergence,
   computeInjurySorenessOverrides,
@@ -90,6 +90,12 @@ export type { ReadinessLevel };
 
 type Session = Awaited<ReturnType<typeof getSession>>;
 
+function deriveBlockFromIntensity(intensityType: IntensityType): 1 | 2 | 3 {
+  if (intensityType === 'heavy') return 1;
+  if (intensityType === 'explosive') return 2;
+  return 3;
+}
+
 export async function runJITForSession(
   session: NonNullable<Session>,
   userId: string,
@@ -108,20 +114,16 @@ export async function runJITForSession(
   const lift = LiftSchema.parse(session.primary_lift);
   const intensityType = IntensityTypeSchema.parse(session.intensity_type);
 
-  // Ad-hoc sessions (no program) have a null block_number by design. Legacy
-  // programmatic sessions can also reach this point with a null block_number
-  // (Sentry react-native#122700262 — older row predates the column being
-  // populated for that program). In both cases, derive the block from
-  // intensity_type instead of crashing the JIT pipeline.
+  // Ad-hoc sessions (no program) have a null block_number by design.
+  // Programmatic deload sessions are also written with block_number=null by
+  // the program generator (program-generator.ts:62), which crashed the JIT
+  // pipeline via BlockNumberSchema.parse(null) — Sentry react-native#122700262.
+  // Derive the block from intensity_type in either case.
   const isAdHoc = session.program_id === null;
   const blockNumber =
     session.block_number !== null
       ? BlockNumberSchema.parse(session.block_number)
-      : intensityType === 'heavy'
-        ? 1
-        : intensityType === 'explosive'
-          ? 2
-          : 3;
+      : deriveBlockFromIntensity(intensityType);
   if (!isAdHoc && session.block_number === null) {
     captureException(
       new Error(


### PR DESCRIPTION
## Summary
- Stop `runJITForSession` from crashing on **deload sessions** — Sentry react-native#122700262 (`ZodError: expected number, received null`).
- Verified in prod: 12 orphan rows, all `intensity_type='deload'`, single user. Confirmed source is `packages/training-engine/src/generator/program-generator.ts:62` (`generateDeloadWeek` writes `blockNumber: null` intentionally — see [follow-up #228](https://github.com/rek/parakeet/issues/228) for the data-contract fix).
- Fall back to the same `intensity_type → block` derivation already used for ad-hoc sessions, via a named `deriveBlockFromIntensity` helper (no nested ternary).
- `captureException` a Sentry warning when this branch fires on a programmatic session, so we can find the orphan rows.

## Why this is safe
- `sessions.block_number` is a nullable `smallint` and `SessionSchema.block_number` is already `.nullable()` — the row shape is valid in the data model; only the JIT entry point treated it as impossible.
- The fallback mapping (`heavy→1`, `explosive→2`, `rep/deload→3`) is identical to the existing ad-hoc path, so behavior for ad-hoc sessions is unchanged. For deload sessions, block 3 is arbitrary — picking the "right" block for aux assignments is best done by fixing the generator (see #228 follow-up). This PR is the safety net.
- `isAdHoc` (used to gate `getActiveAssignments` / `getAuxiliaryPools`) still hinges on `program_id === null`, so programmatic sessions still fetch their assignments — they just no longer crash before getting there.

## Test plan
- [x] `nx run parakeet:typecheck` passes
- [x] `vitest run src/modules/jit` (68/68 pass)
- [x] Verified in prod: predicted orphan rows exist (12 deload sessions, user `73d410b4-…`), including Anette's failing session `f7c7fadf-87d9-44d8-a621-a333df429b26` (squat deload, week 4 day 1, planned 2026-05-25).
- [ ] After merge: confirm new Sentry warning fires once per affected session and the JIT pipeline produces sets instead of erroring.

## Follow-up
- #228 — enable `no-nested-ternary` lint rule and sweep ~145 existing violations.
- The deeper data-contract fix (program generator emitting real `block_number` for deload weeks + backfill of the 12 existing rows) should be its own PR once we decide the right block-number for a deload session.

— posted by Claude Code + Opus 4.7