### PR TITLE
fix(program-generator): deload sessions inherit the block they follow

### DIFF
--- a/docs/features/programs/spec-generator.md
+++ b/docs/features/programs/spec-generator.md
@@ -27,8 +27,9 @@ The `generateProgram` function now creates **structural scaffolding only** — s
 - [x] `generateWeekSessions(weekNumber, blockNumber, weekInBlock, trainingDaysPerWeek, startDate): SessionScaffold[]`
   - Each session has: `weekNumber`, `dayNumber`, `primaryLift`, `intensityType`, `blockNumber`, `isDeload`, `plannedDate`
   - `plannedSets: null` — explicitly null, not an empty array (signals "not yet JIT-generated")
-- [x] `generateDeloadWeek(weekNumber, totalWeeks, trainingDaysPerWeek, startDate): SessionScaffold[]`
+- [x] `generateDeloadWeek(weekNumber, blockNumber, dayOffsets, startDate): SessionScaffold[]`
   - Same structure, `isDeload: true`, `intensityType: 'deload'`
+  - `blockNumber` is the block the deload **follows** (week 4 deload → block 1, week 8 → block 2, final-week deload → previous training week's block). Keeps the JIT pipeline's aux-assignment lookup coherent.
 
 **Type: `SessionScaffold`**
 ```typescript
@@ -37,7 +38,7 @@ interface SessionScaffold {
   dayNumber: number
   primaryLift: Lift
   intensityType: IntensityType
-  blockNumber: 1 | 2 | 3 | null  // null for deload
+  blockNumber: number  // deload sessions inherit the block they follow
   isDeload: boolean
   plannedDate: Date
   plannedSets: null  // always null; populated by JIT generator

--- a/packages/training-engine/src/generator/program-generator.test.ts
+++ b/packages/training-engine/src/generator/program-generator.test.ts
@@ -50,13 +50,13 @@ describe('generateProgram — 10-week 3-day', () => {
     });
   });
 
-  it('week 4: deload (every 4th week)', () => {
+  it('week 4: deload inherits the block it follows (block 1)', () => {
     const week4 = result.sessions.filter((s) => s.weekNumber === 4);
     expect(week4).toHaveLength(3);
     week4.forEach((s) => {
       expect(s.isDeload).toBe(true);
       expect(s.intensityType).toBe('deload');
-      expect(s.blockNumber).toBeNull();
+      expect(s.blockNumber).toBe(1);
     });
   });
 
@@ -82,13 +82,13 @@ describe('generateProgram — 10-week 3-day', () => {
     });
   });
 
-  it('week 10: all 3 sessions are deload', () => {
+  it('week 10: all 3 sessions are deload, inheriting block 3', () => {
     const week10 = result.sessions.filter((s) => s.weekNumber === 10);
     expect(week10).toHaveLength(3);
     week10.forEach((s) => {
       expect(s.isDeload).toBe(true);
       expect(s.intensityType).toBe('deload');
-      expect(s.blockNumber).toBeNull();
+      expect(s.blockNumber).toBe(3);
     });
   });
 

--- a/packages/training-engine/src/generator/program-generator.ts
+++ b/packages/training-engine/src/generator/program-generator.ts
@@ -46,9 +46,15 @@ export function generateWeekSessions(
   });
 }
 
+// A deload session is tagged with the block it follows (e.g. week 4 deload
+// inherits block 1, week 8 follows block 2). This keeps the JIT pipeline's
+// `getActiveAssignments(programId, blockNumber)` lookup coherent — the lifter
+// deloads the same auxiliaries they were just running. Previously this was
+// `blockNumber: null`, which crashed `runJITForSession` via Zod
+// (Sentry react-native#122700262).
 export function generateDeloadWeek(
   weekNumber: number,
-  _totalWeeks: number,
+  blockNumber: number,
   dayOffsets: number[],
   startDate: Date
 ): SessionScaffold[] {
@@ -59,7 +65,7 @@ export function generateDeloadWeek(
       dayNumber: dayIndex + 1,
       primaryLift: lift,
       intensityType: 'deload' as IntensityType,
-      blockNumber: null,
+      blockNumber,
       isDeload: true,
       plannedDate: calculateSessionDate(
         startDate,
@@ -84,8 +90,11 @@ export function generateProgram(
 
   for (let week = 1; week <= totalWeeks; week++) {
     if (isDeloadWeek(week, totalWeeks)) {
+      // Inherit the block of the preceding training week. Clamp to 1 for the
+      // degenerate case of a totalWeeks=1 program (which is itself a deload).
+      const followingBlock = week > 1 ? getBlockNumber(week - 1) : 1;
       sessions.push(
-        ...generateDeloadWeek(week, totalWeeks, dayOffsets, startDate)
+        ...generateDeloadWeek(week, followingBlock, dayOffsets, startDate)
       );
     } else {
       const blockNumber = getBlockNumber(week);

--- a/packages/training-engine/src/types.ts
+++ b/packages/training-engine/src/types.ts
@@ -137,7 +137,8 @@ export interface SessionScaffold {
   dayNumber: number;
   primaryLift: Lift;
   intensityType: IntensityType;
-  blockNumber: number | null; // null for deload week
+  // Deload sessions inherit the block they follow (e.g. week 4 deload → block 1).
+  blockNumber: number;
   isDeload: boolean;
   plannedDate: Date;
   plannedSets: null; // always null; populated by JIT generator


### PR DESCRIPTION
## Summary
Real fix for the deload-session JIT crash that PR #227 patched defensively. The scheduled-program generator was writing `block_number: NULL` for every deload week (`program-generator.ts:62`), which crashed the JIT pipeline via Zod (Sentry react-native#122700262).

A deload week now carries the block of the **immediately preceding training week** — week 4 → block 1, week 8 → block 2, week 12 → block 3, final-week deload → previous training week's block. This keeps `getActiveAssignments(programId, blockNumber)` coherent: the lifter deloads the same auxiliaries they were just running.

## Code changes
- `generateDeloadWeek` signature: `(_totalWeeks: number)` → `(blockNumber: number)`.
- `generateProgram` computes `getBlockNumber(week - 1)` (clamped to 1 for the degenerate `totalWeeks=1` case) and passes it in.
- `SessionScaffold.blockNumber` tightened from `number | null` to `number` — generator no longer emits null.
- Spec doc + two test assertions updated to reflect the new contract.

## Data backfill (12 rows, 1 user — Anette)

Preview confirms the formula produces the expected blocks for every affected row:

```text
program cd152b8f (active, 10w):  wk4 → 1, wk8 → 2, wk10 → 3
program d589960b (archived, 10w):           wk10 → 3
```

### Read-only preview — run first

```sql
SELECT s.id,
       s.program_id,
       s.week_number,
       s.primary_lift,
       s.intensity_type,
       s.status,
       GREATEST(
         CEIL((s.week_number - 1 - FLOOR((s.week_number - 1) / 4)) / 3.0)::int,
         1
       ) AS new_block_number
FROM public.sessions s
WHERE s.program_id IS NOT NULL
  AND s.primary_lift IS NOT NULL
  AND s.block_number IS NULL
  AND s.intensity_type = 'deload'
ORDER BY s.program_id, s.week_number, s.day_number;
```

### Backfill — wrap in a transaction

```sql
BEGIN;

UPDATE public.sessions
SET block_number = GREATEST(
      CEIL((week_number - 1 - FLOOR((week_number - 1) / 4)) / 3.0)::int,
      1
    )
WHERE program_id IS NOT NULL
  AND primary_lift IS NOT NULL
  AND block_number IS NULL
  AND intensity_type = 'deload';

-- Sanity check before commit: should report 0
SELECT COUNT(*) AS still_null
FROM public.sessions
WHERE program_id IS NOT NULL
  AND primary_lift IS NOT NULL
  AND block_number IS NULL
  AND intensity_type = 'deload';

COMMIT;
```

The formula is generic — it'll catch any other affected user (currently none, but it's defensive).

## Test plan
- [x] `nx run training-engine:test` (1560 passed)
- [x] `nx run parakeet:test` (1419 passed)
- [x] `nx run parakeet:typecheck`
- [x] `nx run training-engine:typecheck` — the only 2 errors are pre-existing in `hybrid-jit-generator.test.ts` lines 109/145 (verified on `main` without these changes); not introduced here.
- [ ] After merge + backfill: confirm Anette's `f7c7fadf-…` (squat week 4 deload) generates a JIT session without firing the new Sentry warning from #227.

## Out of scope (intentional)
- Unending-program deloads use a different block formula (`(floor((week-1)/3) % 3) + 1`) — block 2 for week 4, not block 1. They already write a non-null `block_number`, so no crash; leaving the semantic gap to a separate decision.
- DB column stays nullable. The engine no longer emits null, and ad-hoc sessions still legitimately have null `block_number`. Flipping the column to NOT NULL would need its own migration.

— posted by Claude Code + Opus 4.7